### PR TITLE
Allow Users to Customize Key Mapping

### DIFF
--- a/src/ControlMapperRow.js
+++ b/src/ControlMapperRow.js
@@ -1,0 +1,81 @@
+import React, { Component } from "react";
+
+class ControlMapperRow extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      playerOneButton: "",
+      playerTwoButton: "",
+      waitingForKey: 0
+    };
+    this.handleClick = this.handleClick.bind(this);
+  }
+
+  componentDidMount() {
+    var keys = this.props.keys;
+    var button = this.props.button;
+    var playerButtons = [];
+    for (var key in keys) {
+      if (keys[key][0] === 1 && keys[key][1] === button) {
+        playerButtons[0] = keys[key][2];
+        console.log(playerButtons[0]);
+      } else if (keys[key][0] === 2 && keys[key][1] === button) {
+        playerButtons[1] = keys[key][2];
+      }
+    }
+    this.setState({
+      playerOneButton: playerButtons[0],
+      playerTwoButton: playerButtons[1]
+    });
+  }
+
+  componentDidUpdate(prevProps, prevState) {
+    // Prevent setState being called repeatedly
+    if (prevState.waitingForKey !== 0) {
+      var keys = this.props.keys;
+      var button = this.props.button;
+      var playerButtons = [];
+      for (var key in keys) {
+        if (keys[key][0] === 1 && keys[key][1] === button) {
+          playerButtons[0] = keys[key][2];
+          console.log(playerButtons[0]);
+        } else if (keys[key][0] === 2 && keys[key][1] === button) {
+          playerButtons[1] = keys[key][2];
+        }
+      }
+      this.setState({
+        playerOneButton: playerButtons[0],
+        playerTwoButton: playerButtons[1],
+        waitingForKey: 0
+      });
+    }
+  }
+
+  handleClick(player) {
+    this.props.handleClick([player, this.props.button]);
+    this.setState({
+      waitingForKey: player
+    });
+  }
+
+  render() {
+    const waitingText = "Press key...";
+    return (
+      <tr>
+        <td>{this.props.buttonName}</td>
+        <td onClick={() => this.handleClick(1)}>
+          {this.state.waitingForKey === 1
+            ? waitingText
+            : this.state.playerOneButton}
+        </td>
+        <td onClick={() => this.handleClick(2)}>
+          {this.state.waitingForKey === 2
+            ? waitingText
+            : this.state.playerTwoButton}
+        </td>
+      </tr>
+    );
+  }
+}
+
+export default ControlMapperRow;

--- a/src/ControlsModal.js
+++ b/src/ControlsModal.js
@@ -12,14 +12,15 @@ import { Controller } from "jsnes";
 class ControlsModal extends Component {
   constructor(props) {
     super(props);
-    this.state = { keys: undefined, button: undefined };
+    this.state = { keys: props.keys, button: undefined, modified: false };
     this.handleKeyDown = this.handleKeyDown.bind(this);
   }
 
-  componentDidUpdate(props, state) {
-    if (state.keys === undefined && props.keys !== undefined) {
-      this.setState({ keys: this.props.keys });
+  componentWillUnmount() {
+    if (this.state.modified) {
+      this.props.setKeys(this.state.keys);
     }
+    this.removeKeyListener("keydown", this.handleKeyDown);
   }
 
   handleClick(button) {
@@ -41,7 +42,8 @@ class ControlsModal extends Component {
         ...newKeys,
         [event.keyCode]: button
       },
-      button: undefined
+      button: undefined,
+      modified: true
     });
     document.removeEventListener("keydown", this.handleKeyDown);
   }
@@ -51,11 +53,6 @@ class ControlsModal extends Component {
   }
 
   render() {
-    // Remove key listener in case modal is closed before new button is mapped
-    if (!this.props.isOpen) {
-      this.removeKeyListener("keydown", this.handleKeyDown);
-      this.props.setKeys(this.state.keys);
-    }
     return (
       <Modal
         isOpen={this.props.isOpen}

--- a/src/ControlsModal.js
+++ b/src/ControlsModal.js
@@ -8,6 +8,7 @@ import {
   Table
 } from "reactstrap";
 import { Controller } from "jsnes";
+import ControlMapperRow from "./ControlMapperRow";
 
 class ControlsModal extends Component {
   constructor(props) {
@@ -70,102 +71,54 @@ class ControlsModal extends Component {
               </tr>
             </thead>
             <tbody>
-              <tr>
-                <td>Left</td>
-                <td
-                  onClick={() => this.handleClick([1, Controller.BUTTON_LEFT])}
-                >
-                  Left
-                </td>
-                <td
-                  onClick={() => this.handleClick([2, Controller.BUTTON_LEFT])}
-                >
-                  Num-4
-                </td>
-              </tr>
-              <tr>
-                <td>Right</td>
-                <td
-                  onClick={() => this.handleClick([1, Controller.BUTTON_RIGHT])}
-                >
-                  Right
-                </td>
-                <td
-                  onClick={() => this.handleClick([2, Controller.BUTTON_RIGHT])}
-                >
-                  Num-6
-                </td>
-              </tr>
-              <tr>
-                <td>Up</td>
-                <td onClick={() => this.handleClick([1, Controller.BUTTON_UP])}>
-                  Up
-                </td>
-                <td onClick={() => this.handleClick([2, Controller.BUTTON_UP])}>
-                  Num-8
-                </td>
-              </tr>
-              <tr>
-                <td>Down</td>
-                <td
-                  onClick={() => this.handleClick([1, Controller.BUTTON_DOWN])}
-                >
-                  Down
-                </td>
-                <td
-                  onClick={() => this.handleClick([2, Controller.BUTTON_DOWN])}
-                >
-                  Num-2
-                </td>
-              </tr>
-              <tr>
-                <td>A</td>
-                <td onClick={() => this.handleClick([1, Controller.BUTTON_A])}>
-                  X
-                </td>
-                <td onClick={() => this.handleClick([2, Controller.BUTTON_A])}>
-                  Num-7
-                </td>
-              </tr>
-              <tr>
-                <td>B</td>
-                <td onClick={() => this.handleClick([1, Controller.BUTTON_B])}>
-                  Z
-                </td>
-                <td onClick={() => this.handleClick([2, Controller.BUTTON_B])}>
-                  Num-9
-                </td>
-              </tr>
-              <tr>
-                <td>Start</td>
-                <td
-                  onClick={() => this.handleClick([1, Controller.BUTTON_START])}
-                >
-                  Enter
-                </td>
-                <td
-                  onClick={() => this.handleClick([2, Controller.BUTTON_START])}
-                >
-                  Num-1
-                </td>
-              </tr>
-              <tr>
-                <td>Select</td>
-                <td
-                  onClick={() =>
-                    this.handleClick([1, Controller.BUTTON_SELECT])
-                  }
-                >
-                  Ctrl
-                </td>
-                <td
-                  onClick={() =>
-                    this.handleClick([2, Controller.BUTTON_SELECT])
-                  }
-                >
-                  Num-3
-                </td>
-              </tr>
+              <ControlMapperRow
+                buttonName="Left"
+                button={Controller.BUTTON_LEFT}
+                keys={this.state.keys}
+                handleClick={this.listenForKey}
+              />
+              <ControlMapperRow
+                buttonName="Right"
+                button={Controller.BUTTON_RIGHT}
+                keys={this.state.keys}
+                handleClick={this.listenForKey}
+              />
+              <ControlMapperRow
+                buttonName="Up"
+                button={Controller.BUTTON_UP}
+                keys={this.state.keys}
+                handleClick={this.listenForKey}
+              />
+              <ControlMapperRow
+                buttonName="Down"
+                button={Controller.BUTTON_DOWN}
+                keys={this.state.keys}
+                handleClick={this.listenForKey}
+              />
+              <ControlMapperRow
+                buttonName="A"
+                button={Controller.BUTTON_A}
+                keys={this.state.keys}
+                handleClick={this.listenForKey}
+              />
+              <ControlMapperRow
+                buttonName="B"
+                button={Controller.BUTTON_B}
+                keys={this.state.keys}
+                handleClick={this.listenForKey}
+              />
+              <ControlMapperRow
+                buttonName="Start"
+                button={Controller.BUTTON_START}
+                keys={this.state.keys}
+                handleClick={this.listenForKey}
+              />
+              <ControlMapperRow
+                buttonName="Select"
+                button={Controller.BUTTON_SELECT}
+                keys={this.state.keys}
+                handleClick={this.listenForKey}
+              />
             </tbody>
           </Table>
         </ModalBody>

--- a/src/ControlsModal.js
+++ b/src/ControlsModal.js
@@ -7,9 +7,55 @@ import {
   ModalFooter,
   Table
 } from "reactstrap";
+import { Controller } from "jsnes";
 
 class ControlsModal extends Component {
+  constructor(props) {
+    super(props);
+    this.state = { keys: undefined, button: undefined };
+    this.handleKeyDown = this.handleKeyDown.bind(this);
+  }
+
+  componentDidUpdate(props, state) {
+    if (state.keys === undefined && props.keys !== undefined) {
+      this.setState({ keys: this.props.keys });
+    }
+  }
+
+  handleClick(button) {
+    this.setState({ button });
+    document.addEventListener("keydown", this.handleKeyDown);
+  }
+
+  handleKeyDown(event) {
+    var button = this.state.button;
+    var keys = this.state.keys;
+    var newKeys = {};
+    for (var key in keys) {
+      if (keys[key][0] !== button[0] || keys[key][1] !== button[1]) {
+        newKeys[key] = keys[key];
+      }
+    }
+    this.setState({
+      keys: {
+        ...newKeys,
+        [event.keyCode]: button
+      },
+      button: undefined
+    });
+    document.removeEventListener("keydown", this.handleKeyDown);
+  }
+
+  removeKeyListener() {
+    document.removeEventListener("keydown", this.handleKeyDown);
+  }
+
   render() {
+    // Remove key listener in case modal is closed before new button is mapped
+    if (!this.props.isOpen) {
+      this.removeKeyListener("keydown", this.handleKeyDown);
+      this.props.setKeys(this.state.keys);
+    }
     return (
       <Modal
         isOpen={this.props.isOpen}
@@ -29,43 +75,99 @@ class ControlsModal extends Component {
             <tbody>
               <tr>
                 <td>Left</td>
-                <td>Left</td>
-                <td>Num-4</td>
+                <td
+                  onClick={() => this.handleClick([1, Controller.BUTTON_LEFT])}
+                >
+                  Left
+                </td>
+                <td
+                  onClick={() => this.handleClick([2, Controller.BUTTON_LEFT])}
+                >
+                  Num-4
+                </td>
               </tr>
               <tr>
                 <td>Right</td>
-                <td>Right</td>
-                <td>Num-6</td>
+                <td
+                  onClick={() => this.handleClick([1, Controller.BUTTON_RIGHT])}
+                >
+                  Right
+                </td>
+                <td
+                  onClick={() => this.handleClick([2, Controller.BUTTON_RIGHT])}
+                >
+                  Num-6
+                </td>
               </tr>
               <tr>
                 <td>Up</td>
-                <td>Up</td>
-                <td>Num-8</td>
+                <td onClick={() => this.handleClick([1, Controller.BUTTON_UP])}>
+                  Up
+                </td>
+                <td onClick={() => this.handleClick([2, Controller.BUTTON_UP])}>
+                  Num-8
+                </td>
               </tr>
               <tr>
                 <td>Down</td>
-                <td>Down</td>
-                <td>Num-2</td>
+                <td
+                  onClick={() => this.handleClick([1, Controller.BUTTON_DOWN])}
+                >
+                  Down
+                </td>
+                <td
+                  onClick={() => this.handleClick([2, Controller.BUTTON_DOWN])}
+                >
+                  Num-2
+                </td>
               </tr>
               <tr>
                 <td>A</td>
-                <td>X</td>
-                <td>Num-7</td>
+                <td onClick={() => this.handleClick([1, Controller.BUTTON_A])}>
+                  X
+                </td>
+                <td onClick={() => this.handleClick([2, Controller.BUTTON_A])}>
+                  Num-7
+                </td>
               </tr>
               <tr>
                 <td>B</td>
-                <td>Z</td>
-                <td>Num-9</td>
+                <td onClick={() => this.handleClick([1, Controller.BUTTON_B])}>
+                  Z
+                </td>
+                <td onClick={() => this.handleClick([2, Controller.BUTTON_B])}>
+                  Num-9
+                </td>
               </tr>
               <tr>
                 <td>Start</td>
-                <td>Enter</td>
-                <td>Num-1</td>
+                <td
+                  onClick={() => this.handleClick([1, Controller.BUTTON_START])}
+                >
+                  Enter
+                </td>
+                <td
+                  onClick={() => this.handleClick([2, Controller.BUTTON_START])}
+                >
+                  Num-1
+                </td>
               </tr>
               <tr>
                 <td>Select</td>
-                <td>Ctrl</td>
-                <td>Num-3</td>
+                <td
+                  onClick={() =>
+                    this.handleClick([1, Controller.BUTTON_SELECT])
+                  }
+                >
+                  Ctrl
+                </td>
+                <td
+                  onClick={() =>
+                    this.handleClick([2, Controller.BUTTON_SELECT])
+                  }
+                >
+                  Num-3
+                </td>
               </tr>
             </tbody>
           </Table>

--- a/src/ControlsModal.js
+++ b/src/ControlsModal.js
@@ -42,7 +42,10 @@ class ControlsModal extends Component {
     this.setState({
       keys: {
         ...newKeys,
-        [event.keyCode]: button
+        [event.keyCode]: [
+          ...button.slice(0, 2),
+          event.key.length > 1 ? event.key : String(event.key).toUpperCase()
+        ]
       },
       button: undefined,
       modified: true

--- a/src/ControlsModal.js
+++ b/src/ControlsModal.js
@@ -15,6 +15,7 @@ class ControlsModal extends Component {
     super(props);
     this.state = { keys: props.keys, button: undefined, modified: false };
     this.handleKeyDown = this.handleKeyDown.bind(this);
+    this.listenForKey = this.listenForKey.bind(this);
   }
 
   componentWillUnmount() {
@@ -24,7 +25,7 @@ class ControlsModal extends Component {
     this.removeKeyListener("keydown", this.handleKeyDown);
   }
 
-  handleClick(button) {
+  listenForKey(button) {
     this.setState({ button });
     document.addEventListener("keydown", this.handleKeyDown);
   }

--- a/src/KeyboardController.js
+++ b/src/KeyboardController.js
@@ -27,8 +27,22 @@ export default class KeyboardController {
     this.onButtonUp = options.onButtonUp;
   }
 
+  loadKeys = () => {
+    var keys;
+    try {
+      keys = localStorage.getItem("keys");
+      if (keys) {
+        keys = JSON.parse(keys);
+      }
+    } catch (e) {
+      console.log("Failed to get keys from localStorage.", e);
+    }
+
+    this.keys = keys || KEYS;
+  };
+
   handleKeyDown = e => {
-    var key = KEYS[e.keyCode];
+    var key = this.keys[e.keyCode];
     if (key) {
       this.onButtonDown(key[0], key[1]);
       e.preventDefault();
@@ -36,7 +50,7 @@ export default class KeyboardController {
   };
 
   handleKeyUp = e => {
-    var key = KEYS[e.keyCode];
+    var key = this.keys[e.keyCode];
     if (key) {
       this.onButtonUp(key[0], key[1]);
       e.preventDefault();

--- a/src/KeyboardController.js
+++ b/src/KeyboardController.js
@@ -2,23 +2,23 @@ import { Controller } from "jsnes";
 
 // Mapping keyboard code to [controller, button]
 const KEYS = {
-  88: [1, Controller.BUTTON_A], // X
-  89: [1, Controller.BUTTON_B], // Y (Central European keyboard)
-  90: [1, Controller.BUTTON_B], // Z
-  17: [1, Controller.BUTTON_SELECT], // Right Ctrl
-  13: [1, Controller.BUTTON_START], // Enter
-  38: [1, Controller.BUTTON_UP], // Up
-  40: [1, Controller.BUTTON_DOWN], // Down
-  37: [1, Controller.BUTTON_LEFT], // Left
-  39: [1, Controller.BUTTON_RIGHT], // Right
-  103: [2, Controller.BUTTON_A], // Num-7
-  105: [2, Controller.BUTTON_B], // Num-9
-  99: [2, Controller.BUTTON_SELECT], // Num-3
-  97: [2, Controller.BUTTON_START], // Num-1
-  104: [2, Controller.BUTTON_UP], // Num-8
-  98: [2, Controller.BUTTON_DOWN], // Num-2
-  100: [2, Controller.BUTTON_LEFT], // Num-4
-  102: [2, Controller.BUTTON_RIGHT] // Num-6
+  88: [1, Controller.BUTTON_A, "X"], // X
+  89: [1, Controller.BUTTON_B, "Y"], // Y (Central European keyboard)
+  90: [1, Controller.BUTTON_B, "Z"], // Z
+  17: [1, Controller.BUTTON_SELECT, "Right Ctrl"], // Right Ctrl
+  13: [1, Controller.BUTTON_START, "Enter"], // Enter
+  38: [1, Controller.BUTTON_UP, "Up"], // Up
+  40: [1, Controller.BUTTON_DOWN, "Down"], // Down
+  37: [1, Controller.BUTTON_LEFT, "Left"], // Left
+  39: [1, Controller.BUTTON_RIGHT, "Right"], // Right
+  103: [2, Controller.BUTTON_A, "Num-7"], // Num-7
+  105: [2, Controller.BUTTON_B, "Num-9"], // Num-9
+  99: [2, Controller.BUTTON_SELECT, "Num-3"], // Num-3
+  97: [2, Controller.BUTTON_START, "Num-1"], // Num-1
+  104: [2, Controller.BUTTON_UP, "Num-8"], // Num-8
+  98: [2, Controller.BUTTON_DOWN, "Num-2"], // Num-2
+  100: [2, Controller.BUTTON_LEFT, "Num-4"], // Num-4
+  102: [2, Controller.BUTTON_RIGHT, "Num-6"] // Num-6
 };
 
 export default class KeyboardController {

--- a/src/KeyboardController.js
+++ b/src/KeyboardController.js
@@ -41,6 +41,15 @@ export default class KeyboardController {
     this.keys = keys || KEYS;
   };
 
+  setKeys = newKeys => {
+    try {
+      localStorage.setItem("keys", JSON.stringify(newKeys));
+      this.keys = newKeys;
+    } catch (e) {
+      console.log("Failed to set keys in localStorage");
+    }
+  };
+
   handleKeyDown = e => {
     var key = this.keys[e.keyCode];
     if (key) {

--- a/src/RunPage.js
+++ b/src/RunPage.js
@@ -116,20 +116,14 @@ class RunPage extends Component {
                 this.nes.zapperFireUp();
               }}
             />
-            <ControlsModal
-              isOpen={this.state.controlsModal}
-              toggle={this.toggleControlsModal}
-              keys={
-                this.keyboardController
-                  ? this.keyboardController.keys
-                  : undefined
-              }
-              setKeys={
-                this.keyboardController
-                  ? this.keyboardController.setKeys
-                  : undefined
-              }
-            />
+            {this.state.controlsModal && (
+              <ControlsModal
+                isOpen={this.state.controlsModal}
+                toggle={this.toggleControlsModal}
+                keys={this.keyboardController.keys}
+                setKeys={this.keyboardController.setKeys}
+              />
+            )}
           </div>
         )}
       </div>

--- a/src/RunPage.js
+++ b/src/RunPage.js
@@ -119,6 +119,16 @@ class RunPage extends Component {
             <ControlsModal
               isOpen={this.state.controlsModal}
               toggle={this.toggleControlsModal}
+              keys={
+                this.keyboardController
+                  ? this.keyboardController.keys
+                  : undefined
+              }
+              setKeys={
+                this.keyboardController
+                  ? this.keyboardController.setKeys
+                  : undefined
+              }
             />
           </div>
         )}

--- a/src/RunPage.js
+++ b/src/RunPage.js
@@ -171,6 +171,10 @@ class RunPage extends Component {
       onButtonDown: this.nes.buttonDown,
       onButtonUp: this.nes.buttonUp
     });
+
+    // Load keys from localStorage (if they exist)
+    this.keyboardController.loadKeys();
+
     document.addEventListener("keydown", this.keyboardController.handleKeyDown);
     document.addEventListener("keyup", this.keyboardController.handleKeyUp);
     document.addEventListener(


### PR DESCRIPTION
Having the directional buttons on the right and action buttons on the left did not feel natural.

This PR allows users to customize what keys are mapped to each player's controller buttons and saves those changes to localStorage. Although it wasn't made to fix the issue, it does adequately address [#65](https://github.com/bfirsh/jsnes-web/issues/65).

It's definitely not as cleanly implemented as I would like, but it's a joy to play with the keys I prefer. I didn't want to hold out from others being able to have the same experience.

### Note
If browser does not allow access to localStorage, it will silently fail and maintain the default key mapping. We could get past that, but I'm not sure it would maintain those preferences past a refresh or ROM change.

I was only able to test these changes on recent versions of Chrome and Firefox. Bandwidth limitations kept me from downloading other browsers for testing.