### PR TITLE
Persist drag&dropped ROM files in localStorage

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@ To automatically format all your code, run:
 
 ## Adding roms
 
+### Add ROMs for yourself using localStorage
+
+Navigate to the server public root (e.g. `http://localhost:3000`), click "+ Add ROM files" and follow the instructions. The ROMs will be saved into your browser cache and other users will not be able to access them.
+
+### Add ROMs for all users
+
 Open `src/config.js` and add a new key under the defined `config.ROMS`. For example:
 
     myrom: {

--- a/src/ListPage.css
+++ b/src/ListPage.css
@@ -1,0 +1,12 @@
+.ListPage .list-group-item .delete {
+  color: red;
+  margin-left: 0.8em;
+  font-size: 1.5em;
+  line-height: 1em;
+  position: relative;
+  top: 2px;
+}
+
+.ListPage .list-group-item .delete:hover {
+  color: darkred;
+}

--- a/src/ListPage.js
+++ b/src/ListPage.js
@@ -88,6 +88,8 @@ class ListPage extends Component {
     );
   }
 
+  updateLibrary = () => { this.setState({romLibrary: RomLibrary.load()}) }
+
   handleDragOver = e => {
     e.preventDefault();
     e.dataTransfer.dropEffect = "copy";
@@ -100,7 +102,7 @@ class ListPage extends Component {
       ? e.dataTransfer.items[0].getAsFile()
       : e.dataTransfer.files[0];
 
-    RomLibrary.save(file)
+    RomLibrary.save(file).then(this.updateLibrary)
   };
 }
 

--- a/src/ListPage.js
+++ b/src/ListPage.js
@@ -61,21 +61,26 @@ class ListPage extends Component {
             <div>
               <p>
                 <Button
-                  color={this.state.showRomLibraryInfo ? "secondary" : "primary"}
+                  color={
+                    this.state.showRomLibraryInfo ? "secondary" : "primary"
+                  }
                   onClick={() =>
                     this.setState({
                       showRomLibraryInfo: !this.state.showRomLibraryInfo
                     })
                   }
                 >
-                  {this.state.showRomLibraryInfo ? "- Collapse ROM info" : "+ Add ROM files"}
+                  {this.state.showRomLibraryInfo
+                    ? "- Collapse ROM info"
+                    : "+ Add ROM files"}
                 </Button>
               </p>
               {this.state.showRomLibraryInfo ? (
                 <p>
                   Drag &amp; drop your desired ROM files to this window and they
-                  will be copied into your local browser cache. They can be accessed
-                  later whenever you visit this page, but not by others.
+                  will be copied into your local browser cache. They can be
+                  accessed later whenever you visit this page, but not by
+                  others.
                 </p>
               ) : null}
             </div>

--- a/src/ListPage.js
+++ b/src/ListPage.js
@@ -100,40 +100,7 @@ class ListPage extends Component {
       ? e.dataTransfer.items[0].getAsFile()
       : e.dataTransfer.files[0];
 
-    const reader = new FileReader();
-
-    const asHex = (buffer) => {
-      return Array.from(new Uint8Array (buffer))
-        .map (b => b.toString (16).padStart (2, "0"))
-        .join ("")
-    }
-
-    reader.onload = function(readFile) {
-      const byteString = readFile.target.result;
-      const ab = new ArrayBuffer(byteString.length)
-      var ia = new Uint8Array(ab)
-
-      for (var i = 0; i < byteString.length; i++) {
-        ia[i] = byteString.charCodeAt(i);
-      }
-      const digest = crypto.subtle.digest('SHA-1', ab)
-      digest.then((buffer) => {
-        const hash = asHex(buffer)
-        const savedRomInfo = localStorage.getItem('savedRomInfo')
-        const existingLibrary = savedRomInfo ? JSON.parse(savedRomInfo) : []
-
-        const newRomInfo = JSON.stringify(existingLibrary.concat([{
-          name: file.name,
-          hash: hash,
-          added: Date.now()
-        }]))
-
-        localStorage.setItem('savedRomInfo', newRomInfo)
-        localStorage.setItem('blob-'+hash, readFile.target.result)
-      })
-    }
-
-    reader.readAsBinaryString(file);
+    RomLibrary.save(file)
   };
 }
 

--- a/src/ListPage.js
+++ b/src/ListPage.js
@@ -11,12 +11,23 @@ class ListPage extends Component {
     super(props);
     this.state = {
       romLibrary: RomLibrary.load(),
-      showRomLibraryInfo: false
+      showRomLibraryInfo: false,
+      editingRoms: false
     };
   }
   render() {
+    const editingRoms = this.state.editingRoms
+    const deleteRom = this.deleteRom
     const romLib = this.state.romLibrary.map(function(o) {
-      return <a href={"run/local-" + o.hash}><div key={o.hash} className="list-group-item">{o.name} <span className="float-right">&rsaquo;</span></div></a>
+      return <a href={"run/local-" + o.hash}>
+        <div key={o.hash} className="list-group-item">
+          {o.name}
+          {editingRoms ?
+            <Button className="float-right" size="sm" color="danger" onClick={(e) => { e.preventDefault(); deleteRom(o.hash) }}>Delete</Button>
+            : <span className="float-right">&rsaquo;</span>
+          }
+        </div>
+      </a>
     })
 
     return (
@@ -45,7 +56,15 @@ class ListPage extends Component {
             </div>
 
             {
-              romLib.length > 0 ? <div><h2>Your ROM library</h2><div className="mb-4">{romLib}</div></div> : null
+              romLib.length > 0 ?
+                <div>
+                  <h2>Your ROM library</h2>
+                  <p><Button outline color="secondary" size="sm" onClick={this.toggleRomEditing}>
+                    {this.state.editingRoms ? "Stop editing ROMs" : "Edit ROMs"}
+                  </Button></p>
+                  <div className="mb-4">{romLib}</div>
+                </div>
+                : null
             }
 
             <h2>Preinstalled ROMs</h2>
@@ -88,6 +107,13 @@ class ListPage extends Component {
     );
   }
 
+  deleteRom = (hash) => {
+    RomLibrary.delete(hash)
+    this.updateLibrary()
+  }
+
+  toggleRomEditing = () => this.setState({editingRoms: !this.state.editingRoms})
+
   updateLibrary = () => { this.setState({romLibrary: RomLibrary.load()}) }
 
   handleDragOver = e => {
@@ -102,6 +128,7 @@ class ListPage extends Component {
       ? e.dataTransfer.items[0].getAsFile()
       : e.dataTransfer.files[0];
 
+    this.setState({editingRoms: false})
     RomLibrary.save(file).then(this.updateLibrary)
   };
 }

--- a/src/ListPage.js
+++ b/src/ListPage.js
@@ -61,14 +61,14 @@ class ListPage extends Component {
             <div>
               <p>
                 <Button
-                  color="primary"
+                  color={this.state.showRomLibraryInfo ? "secondary" : "primary"}
                   onClick={() =>
                     this.setState({
                       showRomLibraryInfo: !this.state.showRomLibraryInfo
                     })
                   }
                 >
-                  + Add ROM files
+                  {this.state.showRomLibraryInfo ? "- Collapse ROM info" : "+ Add ROM files"}
                 </Button>
               </p>
               {this.state.showRomLibraryInfo ? (

--- a/src/ListPage.js
+++ b/src/ListPage.js
@@ -44,11 +44,9 @@ class ListPage extends Component {
               }
             </div>
 
-            <h2>Your ROM library</h2>
-
-            <div className="mb-4">
-              {romLib}
-            </div>
+            {
+              romLib.length > 0 ? <div><h2>Your ROM library</h2><div className="mb-4">{romLib}</div></div> : null
+            }
 
             <h2>Preinstalled ROMs</h2>
 

--- a/src/ListPage.js
+++ b/src/ListPage.js
@@ -74,8 +74,8 @@ class ListPage extends Component {
               {this.state.showRomLibraryInfo ? (
                 <p>
                   Drag &amp; drop your desired ROM files to this window and they
-                  will be copied into your local browser cache to be accessed
-                  later whenever you visit this page.
+                  will be copied into your local browser cache. They can be accessed
+                  later whenever you visit this page, but not by others.
                 </p>
               ) : null}
             </div>

--- a/src/ListPage.js
+++ b/src/ListPage.js
@@ -4,7 +4,7 @@ import { ListGroup, Button } from "reactstrap";
 import { Link } from "react-router-dom";
 import config from "./config";
 
-import RomLibrary from './RomLibrary'
+import RomLibrary from "./RomLibrary";
 
 class ListPage extends Component {
   constructor(props) {
@@ -16,19 +16,32 @@ class ListPage extends Component {
     };
   }
   render() {
-    const editingRoms = this.state.editingRoms
-    const deleteRom = this.deleteRom
+    const editingRoms = this.state.editingRoms;
+    const deleteRom = this.deleteRom;
     const romLib = this.state.romLibrary.map(function(o) {
-      return <a href={"run/local-" + o.hash}>
-        <div key={o.hash} className="list-group-item">
-          {o.name}
-          {editingRoms ?
-            <Button className="float-right" size="sm" color="danger" onClick={(e) => { e.preventDefault(); deleteRom(o.hash) }}>Delete</Button>
-            : <span className="float-right">&rsaquo;</span>
-          }
-        </div>
-      </a>
-    })
+      return (
+        <a href={"run/local-" + o.hash}>
+          <div key={o.hash} className="list-group-item">
+            {o.name}
+            {editingRoms ? (
+              <Button
+                className="float-right"
+                size="sm"
+                color="danger"
+                onClick={e => {
+                  e.preventDefault();
+                  deleteRom(o.hash);
+                }}
+              >
+                Delete
+              </Button>
+            ) : (
+              <span className="float-right">&rsaquo;</span>
+            )}
+          </div>
+        </a>
+      );
+    });
 
     return (
       <div
@@ -46,26 +59,43 @@ class ListPage extends Component {
               </p>
             </header>
             <div>
-              <p><Button color="primary" onClick={() => this.setState({showRomLibraryInfo: !this.state.showRomLibraryInfo}) }>+ Add ROM files</Button></p>
-              { this.state.showRomLibraryInfo ?
+              <p>
+                <Button
+                  color="primary"
+                  onClick={() =>
+                    this.setState({
+                      showRomLibraryInfo: !this.state.showRomLibraryInfo
+                    })
+                  }
+                >
+                  + Add ROM files
+                </Button>
+              </p>
+              {this.state.showRomLibraryInfo ? (
                 <p>
-                  Drag &amp; drop your desired ROM files to this window and they will be copied into your local
-                  browser cache to be accessed later whenever you visit this page.
-                </p> : null
-              }
+                  Drag &amp; drop your desired ROM files to this window and they
+                  will be copied into your local browser cache to be accessed
+                  later whenever you visit this page.
+                </p>
+              ) : null}
             </div>
 
-            {
-              romLib.length > 0 ?
-                <div>
-                  <h2>Your ROM library</h2>
-                  <p><Button outline color="secondary" size="sm" onClick={this.toggleRomEditing}>
+            {romLib.length > 0 ? (
+              <div>
+                <h2>Your ROM library</h2>
+                <p>
+                  <Button
+                    outline
+                    color="secondary"
+                    size="sm"
+                    onClick={this.toggleRomEditing}
+                  >
                     {this.state.editingRoms ? "Stop editing ROMs" : "Edit ROMs"}
-                  </Button></p>
-                  <div className="mb-4">{romLib}</div>
-                </div>
-                : null
-            }
+                  </Button>
+                </p>
+                <div className="mb-4">{romLib}</div>
+              </div>
+            ) : null}
 
             <h2>Preinstalled ROMs</h2>
 
@@ -107,14 +137,17 @@ class ListPage extends Component {
     );
   }
 
-  deleteRom = (hash) => {
-    RomLibrary.delete(hash)
-    this.updateLibrary()
-  }
+  deleteRom = hash => {
+    RomLibrary.delete(hash);
+    this.updateLibrary();
+  };
 
-  toggleRomEditing = () => this.setState({editingRoms: !this.state.editingRoms})
+  toggleRomEditing = () =>
+    this.setState({ editingRoms: !this.state.editingRoms });
 
-  updateLibrary = () => { this.setState({romLibrary: RomLibrary.load()}) }
+  updateLibrary = () => {
+    this.setState({ romLibrary: RomLibrary.load() });
+  };
 
   handleDragOver = e => {
     e.preventDefault();
@@ -128,8 +161,8 @@ class ListPage extends Component {
       ? e.dataTransfer.items[0].getAsFile()
       : e.dataTransfer.files[0];
 
-    this.setState({editingRoms: false})
-    RomLibrary.save(file).then(this.updateLibrary)
+    this.setState({ editingRoms: false });
+    RomLibrary.save(file).then(this.updateLibrary);
   };
 }
 

--- a/src/RomLibrary.js
+++ b/src/RomLibrary.js
@@ -25,7 +25,7 @@ const hashFile = function(byteString) {
 
 const RomLibrary = {
   getRomInfoByHash: function(hash) {
-    return this.load().find(rom => rom.hash === hash)
+    return this.load().find(rom => rom.hash === hash);
   },
   save: function(file) {
     return pFileReader(file)

--- a/src/RomLibrary.js
+++ b/src/RomLibrary.js
@@ -25,7 +25,7 @@ const hashFile = function(byteString) {
 
 const RomLibrary = {
   save: function(file) {
-    pFileReader(file).then(function(readFile) {
+    return pFileReader(file).then(function(readFile) {
       const byteString = readFile.target.result;
       return hashFile(byteString).then((hash) =>{ return {hash, byteString} })
     }).then(({hash, byteString}) => {

--- a/src/RomLibrary.js
+++ b/src/RomLibrary.js
@@ -1,58 +1,69 @@
 const pFileReader = function(file) {
   return new Promise((resolve, reject) => {
     var reader = new FileReader();
-    reader.onload = resolve
+    reader.onload = resolve;
     reader.readAsBinaryString(file);
-  })
-}
+  });
+};
 
 const hashFile = function(byteString) {
-  const asHex = (buffer) => {
-      return Array.from(new Uint8Array (buffer))
-        .map (b => b.toString (16).padStart (2, "0"))
-        .join ("")
-    }
+  const asHex = buffer => {
+    return Array.from(new Uint8Array(buffer))
+      .map(b => b.toString(16).padStart(2, "0"))
+      .join("");
+  };
 
-  const ab = new ArrayBuffer(byteString.length)
-  var ia = new Uint8Array(ab)
+  const ab = new ArrayBuffer(byteString.length);
+  var ia = new Uint8Array(ab);
 
   for (var i = 0; i < byteString.length; i++) {
     ia[i] = byteString.charCodeAt(i);
   }
 
-  return crypto.subtle.digest('SHA-1', ab).then(asHex)
-}
+  return crypto.subtle.digest("SHA-1", ab).then(asHex);
+};
 
 const RomLibrary = {
   save: function(file) {
-    return pFileReader(file).then(function(readFile) {
-      const byteString = readFile.target.result;
-      return hashFile(byteString).then((hash) =>{ return {hash, byteString} })
-    }).then(({hash, byteString}) => {
-      const savedRomInfo = localStorage.getItem('savedRomInfo')
-      const existingLibrary = savedRomInfo ? JSON.parse(savedRomInfo) : []
+    return pFileReader(file)
+      .then(function(readFile) {
+        const byteString = readFile.target.result;
+        return hashFile(byteString).then(hash => {
+          return { hash, byteString };
+        });
+      })
+      .then(({ hash, byteString }) => {
+        const savedRomInfo = localStorage.getItem("savedRomInfo");
+        const existingLibrary = savedRomInfo ? JSON.parse(savedRomInfo) : [];
 
-      const newRomInfo = JSON.stringify(existingLibrary.concat([{
-        name: file.name,
-        hash: hash,
-        added: Date.now()
-      }]))
+        const newRomInfo = JSON.stringify(
+          existingLibrary.concat([
+            {
+              name: file.name,
+              hash: hash,
+              added: Date.now()
+            }
+          ])
+        );
 
-      localStorage.setItem('savedRomInfo', newRomInfo)
-      localStorage.setItem('blob-'+hash, byteString)
-    })
+        localStorage.setItem("savedRomInfo", newRomInfo);
+        localStorage.setItem("blob-" + hash, byteString);
+      });
   },
   load: function() {
-    const localData = localStorage.getItem('savedRomInfo')
-    if (!localData) return []
-    const savedRomInfo = JSON.parse(localStorage.getItem('savedRomInfo'))
-    return savedRomInfo || []
+    const localData = localStorage.getItem("savedRomInfo");
+    if (!localData) return [];
+    const savedRomInfo = JSON.parse(localStorage.getItem("savedRomInfo"));
+    return savedRomInfo || [];
   },
   delete: function(hash) {
-    const existingLibrary = this.load()
-    localStorage.removeItem('blob-'+hash)
-    localStorage.setItem('savedRomInfo', JSON.stringify(existingLibrary.filter((rom) => rom.hash !== hash)))
+    const existingLibrary = this.load();
+    localStorage.removeItem("blob-" + hash);
+    localStorage.setItem(
+      "savedRomInfo",
+      JSON.stringify(existingLibrary.filter(rom => rom.hash !== hash))
+    );
   }
-}
+};
 
 export default RomLibrary;

--- a/src/RomLibrary.js
+++ b/src/RomLibrary.js
@@ -1,14 +1,20 @@
+const pFileReader = function(file) {
+  return new Promise((resolve, reject) => {
+    var reader = new FileReader();
+    reader.onload = resolve
+    reader.readAsBinaryString(file);
+  })
+}
+
 const RomLibrary = {
   save: function(file) {
-    const reader = new FileReader();
-
     const asHex = (buffer) => {
       return Array.from(new Uint8Array (buffer))
         .map (b => b.toString (16).padStart (2, "0"))
         .join ("")
     }
 
-    reader.onload = function(readFile) {
+    pFileReader(file).then(function(readFile) {
       const byteString = readFile.target.result;
       const ab = new ArrayBuffer(byteString.length)
       var ia = new Uint8Array(ab)
@@ -31,9 +37,7 @@ const RomLibrary = {
         localStorage.setItem('savedRomInfo', newRomInfo)
         localStorage.setItem('blob-'+hash, readFile.target.result)
       })
-    }
-
-    reader.readAsBinaryString(file);
+    })
   },
   load: function() {
     const localData = localStorage.getItem('savedRomInfo')

--- a/src/RomLibrary.js
+++ b/src/RomLibrary.js
@@ -47,6 +47,11 @@ const RomLibrary = {
     if (!localData) return []
     const savedRomInfo = JSON.parse(localStorage.getItem('savedRomInfo'))
     return savedRomInfo || []
+  },
+  delete: function(hash) {
+    const existingLibrary = this.load()
+    localStorage.removeItem('blob-'+hash)
+    localStorage.setItem('savedRomInfo', JSON.stringify(existingLibrary.filter((rom) => rom.hash !== hash)))
   }
 }
 

--- a/src/RomLibrary.js
+++ b/src/RomLibrary.js
@@ -1,0 +1,13 @@
+const RomLibrary = {
+  save: function() {
+
+  },
+  load: function() {
+    const localData = localStorage.getItem('savedRomInfo')
+    if (!localData) return []
+    const savedRomInfo = JSON.parse(localStorage.getItem('savedRomInfo'))
+    return savedRomInfo || []
+  }
+}
+
+export default RomLibrary;

--- a/src/RomLibrary.js
+++ b/src/RomLibrary.js
@@ -1,6 +1,39 @@
 const RomLibrary = {
-  save: function() {
+  save: function(file) {
+    const reader = new FileReader();
 
+    const asHex = (buffer) => {
+      return Array.from(new Uint8Array (buffer))
+        .map (b => b.toString (16).padStart (2, "0"))
+        .join ("")
+    }
+
+    reader.onload = function(readFile) {
+      const byteString = readFile.target.result;
+      const ab = new ArrayBuffer(byteString.length)
+      var ia = new Uint8Array(ab)
+
+      for (var i = 0; i < byteString.length; i++) {
+        ia[i] = byteString.charCodeAt(i);
+      }
+      const digest = crypto.subtle.digest('SHA-1', ab)
+      digest.then((buffer) => {
+        const hash = asHex(buffer)
+        const savedRomInfo = localStorage.getItem('savedRomInfo')
+        const existingLibrary = savedRomInfo ? JSON.parse(savedRomInfo) : []
+
+        const newRomInfo = JSON.stringify(existingLibrary.concat([{
+          name: file.name,
+          hash: hash,
+          added: Date.now()
+        }]))
+
+        localStorage.setItem('savedRomInfo', newRomInfo)
+        localStorage.setItem('blob-'+hash, readFile.target.result)
+      })
+    }
+
+    reader.readAsBinaryString(file);
   },
   load: function() {
     const localData = localStorage.getItem('savedRomInfo')

--- a/src/RomLibrary.js
+++ b/src/RomLibrary.js
@@ -39,18 +39,18 @@ const RomLibrary = {
         const savedRomInfo = localStorage.getItem("savedRomInfo");
         const existingLibrary = savedRomInfo ? JSON.parse(savedRomInfo) : [];
 
-        const newRomInfo = JSON.stringify(
-          existingLibrary.concat([
-            {
-              name: file.name,
-              hash: hash,
-              added: Date.now()
-            }
-          ])
-        );
+        const rom = {
+          name: file.name,
+          hash: hash,
+          added: Date.now()
+        };
+
+        const newRomInfo = JSON.stringify(existingLibrary.concat([rom]));
 
         localStorage.setItem("savedRomInfo", newRomInfo);
         localStorage.setItem("blob-" + hash, byteString);
+
+        return rom;
       });
   },
   load: function() {

--- a/src/RomLibrary.js
+++ b/src/RomLibrary.js
@@ -24,6 +24,9 @@ const hashFile = function(byteString) {
 };
 
 const RomLibrary = {
+  getRomInfoByHash: function(hash) {
+    return this.load().find(rom => rom.hash === hash)
+  },
   save: function(file) {
     return pFileReader(file)
       .then(function(readFile) {

--- a/src/RunPage.js
+++ b/src/RunPage.js
@@ -41,7 +41,7 @@ class RunPage extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      rom: null,
+      romName: null,
       romData: null,
       running: false,
       paused: false,
@@ -71,7 +71,7 @@ class RunPage extends Component {
           <ul className="navbar-nav ml-auto mr-auto">
             <li className="navitem">
               <span className="navbar-text mr-3">
-                {this.state.rom && this.state.rom.description}
+                {this.state.romName}
               </span>
             </li>
           </ul>
@@ -163,18 +163,18 @@ class RunPage extends Component {
     if (this.props.match.params.slug) {
       const slug = this.props.match.params.slug;
       const isLocalROM = /^local-/.test(slug);
-      const savedString = localStorage.getItem("blob-" + slug.split("-")[1]);
-      const rom = isLocalROM ? savedString : config.ROMS[slug];
-      if (!rom) {
+      const romInfo = config.ROMS[slug]
+      if (!isLocalROM && !romInfo) {
         this.setState({ error: `No such ROM: ${slug}` });
         return;
       }
-      this.setState({ rom: rom });
       if (isLocalROM) {
-        this.handleLoaded(rom);
+        const localROMData = localStorage.getItem("blob-" + slug.split("-")[1]);
+        this.handleLoaded(localROMData);
       } else {
+        this.setState({ romName: romInfo.name });
         this.currentRequest = loadBinary(
-          rom.url,
+          romInfo.url,
           (err, data) => {
             if (err) {
               this.setState({ error: `Error loading ROM: ${err.message}` });

--- a/src/RunPage.js
+++ b/src/RunPage.js
@@ -162,8 +162,8 @@ class RunPage extends Component {
   load = () => {
     if (this.props.match.params.slug) {
       const slug = this.props.match.params.slug;
-      const isLocalROM = /^local-/.test(slug)
-      const savedString = localStorage.getItem('blob-'+slug.split('-')[1])
+      const isLocalROM = /^local-/.test(slug);
+      const savedString = localStorage.getItem("blob-" + slug.split("-")[1]);
       const rom = isLocalROM ? savedString : config.ROMS[slug];
       if (!rom) {
         this.setState({ error: `No such ROM: ${slug}` });
@@ -171,7 +171,7 @@ class RunPage extends Component {
       }
       this.setState({ rom: rom });
       if (isLocalROM) {
-        this.handleLoaded(rom)
+        this.handleLoaded(rom);
       } else {
         this.currentRequest = loadBinary(
           rom.url,

--- a/src/RunPage.js
+++ b/src/RunPage.js
@@ -162,23 +162,29 @@ class RunPage extends Component {
   load = () => {
     if (this.props.match.params.slug) {
       const slug = this.props.match.params.slug;
-      const rom = config.ROMS[slug];
+      const isLocalROM = /^local-/.test(slug)
+      const savedString = localStorage.getItem('blob-'+slug.split('-')[1])
+      const rom = isLocalROM ? savedString : config.ROMS[slug];
       if (!rom) {
         this.setState({ error: `No such ROM: ${slug}` });
         return;
       }
       this.setState({ rom: rom });
-      this.currentRequest = loadBinary(
-        rom.url,
-        (err, data) => {
-          if (err) {
-            this.setState({ error: `Error loading ROM: ${err.message}` });
-          } else {
-            this.handleLoaded(data);
-          }
-        },
-        this.handleProgress
-      );
+      if (isLocalROM) {
+        this.handleLoaded(rom)
+      } else {
+        this.currentRequest = loadBinary(
+          rom.url,
+          (err, data) => {
+            if (err) {
+              this.setState({ error: `Error loading ROM: ${err.message}` });
+            } else {
+              this.handleLoaded(data);
+            }
+          },
+          this.handleProgress
+        );
+      }
     } else if (this.props.location.state && this.props.location.state.file) {
       let reader = new FileReader();
       reader.readAsBinaryString(this.props.location.state.file);

--- a/src/RunPage.js
+++ b/src/RunPage.js
@@ -5,6 +5,7 @@ import { Link } from "react-router-dom";
 import config from "./config";
 import ControlsModal from "./ControlsModal";
 import Emulator from "./Emulator";
+import RomLibrary from "./RomLibrary"
 
 import "./RunPage.css";
 
@@ -163,16 +164,19 @@ class RunPage extends Component {
     if (this.props.match.params.slug) {
       const slug = this.props.match.params.slug;
       const isLocalROM = /^local-/.test(slug);
-      const romInfo = config.ROMS[slug]
-      if (!isLocalROM && !romInfo) {
+      const romHash = slug.split("-")[1];
+      const romInfo = isLocalROM ? RomLibrary.getRomInfoByHash(romHash) : config.ROMS[slug]
+
+      if (!romInfo) {
         this.setState({ error: `No such ROM: ${slug}` });
         return;
       }
+      this.setState({ romName: romInfo.name });
+
       if (isLocalROM) {
-        const localROMData = localStorage.getItem("blob-" + slug.split("-")[1]);
+        const localROMData = localStorage.getItem("blob-" + romHash);
         this.handleLoaded(localROMData);
       } else {
-        this.setState({ romName: romInfo.name });
         this.currentRequest = loadBinary(
           romInfo.url,
           (err, data) => {

--- a/src/RunPage.js
+++ b/src/RunPage.js
@@ -5,7 +5,7 @@ import { Link } from "react-router-dom";
 import config from "./config";
 import ControlsModal from "./ControlsModal";
 import Emulator from "./Emulator";
-import RomLibrary from "./RomLibrary"
+import RomLibrary from "./RomLibrary";
 
 import "./RunPage.css";
 
@@ -71,9 +71,7 @@ class RunPage extends Component {
           </ul>
           <ul className="navbar-nav ml-auto mr-auto">
             <li className="navitem">
-              <span className="navbar-text mr-3">
-                {this.state.romName}
-              </span>
+              <span className="navbar-text mr-3">{this.state.romName}</span>
             </li>
           </ul>
           <ul className="navbar-nav" style={{ width: "200px" }}>
@@ -165,7 +163,9 @@ class RunPage extends Component {
       const slug = this.props.match.params.slug;
       const isLocalROM = /^local-/.test(slug);
       const romHash = slug.split("-")[1];
-      const romInfo = isLocalROM ? RomLibrary.getRomInfoByHash(romHash) : config.ROMS[slug]
+      const romInfo = isLocalROM
+        ? RomLibrary.getRomInfoByHash(romHash)
+        : config.ROMS[slug];
 
       if (!romInfo) {
         this.setState({ error: `No such ROM: ${slug}` });


### PR DESCRIPTION
It's not perfect yet, but definitely usable. IMO, it's in a good enough shape to merge into master. What do you think?

Features:

* ROMs that are drag&dropped will persist over browser sessions, so they do not need to be drag&dropped again when you want to play your own ROMs and there's no need to edit configuration files. (Unless you want a ROM to be playable by all users that visit the site)
* On the front page there is now a separate list for ROMs that have been added for the user.
* "Add ROM files" button on the front page that can't be missed. In current master version drag&drop functionality is a bit difficult to discover.
* Persisted ROMs can be deleted.

Some things to add later:

- [ ] Delete button is not properly centered when editing persisted ROMs. It's a couple of pixels off, but I am not sure how to fix this idiomatically with reactstrap. I could do a `position: relative` type of hack but that's probably not good, right?
- [ ] Indicate how much localStorage space is left
- [ ] Ability to delete all localStorage-persisted roms at once
- [ ] Disallow adding files that are not NES roms
- [ ] Disallow NES roms that match the hash of previously uploaded roms, preventing duplicates
- [ ] Ability to edit the names of the added ROMs
- [ ] Allow zipped NES roms, and automatically zip all non-zipped roms to save space in localStorage
- [ ] Expand drag&drop area to the whole window
- [ ] Animate adding and deleting ROMs from/to the library
- [x] ~~Display ROM title on RunPage when playing a persisted game~~ Done
- [ ] General library management functions: play count, ROM list ordering by different criteria etc.