### PR TITLE
Fix issues with game speed when using 48KHz sound

### DIFF
--- a/src/Emulator.js
+++ b/src/Emulator.js
@@ -71,7 +71,8 @@ class Emulator extends Component {
     this.nes = new NES({
       onFrame: this.screen.setBuffer,
       onStatusUpdate: console.log,
-      onAudioSample: this.speakers.writeSample
+      onAudioSample: this.speakers.writeSample,
+      sampleRate: this.speakers.getSampleRate()
     });
 
     // For debugging. (["nes"] instead of .nes to avoid VS Code type errors.)

--- a/src/Speakers.js
+++ b/src/Speakers.js
@@ -8,6 +8,16 @@ export default class Speakers {
     this.buffer = new RingBuffer(this.bufferSize * 2);
   }
 
+  getSampleRate() {
+    if (!window.AudioContext) {
+      return 44100;
+    }
+    let myCtx = new window.AudioContext();
+    let sampleRate = myCtx.sampleRate;
+    myCtx.close();
+    return sampleRate;
+  }
+
   start() {
     // Audio is not supported
     if (!window.AudioContext) {


### PR DESCRIPTION
On audio buffer underrun, more frames are rendered to catchup. Jsnes is configured to produce sound at 44.1KHz by default. Prior to this change, systems using 48KHz sound would cause the game to run at approx 110% speed