### PR TITLE
Rewrite timing module

### DIFF
--- a/src/Emulator.js
+++ b/src/Emulator.js
@@ -57,13 +57,13 @@ class Emulator extends Component {
           "Buffer underrun, running another frame to try and catch up"
         );
 
-        this.nes.frame();
+        this.frameTimer.generateFrame();
         // desiredSize will be 2048, and the NES produces 1468 samples on each
         // frame so we might need a second frame to be run. Give up after that
         // though -- the system is not catching up
         if (this.speakers.buffer.size() < desiredSize) {
           console.log("Still buffer underrun, running a second frame");
-          this.nes.frame();
+          this.frameTimer.generateFrame();
         }
       }
     });

--- a/src/FrameTimer.js
+++ b/src/FrameTimer.js
@@ -1,112 +1,76 @@
-// FrameTimer is two timers: one which triggers at 60 FPS, and the other which
-// triggers whenever there is an animation frame.
-//
-// Normally, the animation frame is 60 FPS, but if it isn't, we need to
-// bodge it by setting up another timer.
-//
-// Why not just use the bodge all the time? If the animation frame is 60 FPS,
-// then it is a much more accurate timer than setInterval. Also, two timers
-// will sometimes be out of sync, causing missed frames.
+const FPS = 60.098;
+
 export default class FrameTimer {
   constructor(props) {
     // Run at 60 FPS
     this.onGenerateFrame = props.onGenerateFrame;
     // Run on animation frame
     this.onWriteFrame = props.onWriteFrame;
-
-    // Whether to fire events or not
-    this.running = false;
-
-    // Bodge mode and calibration
-    this.bodgeMode = false;
-
-    // Calibration config
-    this.desiredFPS = 60;
-    this.calibrationDelay = 200; // time to wait before starting
-    this.calibrationFrames = 10; // number of frames to calibrate with
-    this.calibrationTolerance = 5; // +/- desired FPS to consider correct
-
-    // Calibration state
-    this.calibrating = false;
-    this.calibrationStartTime = null;
-    this.calibrationCurrentFrames = null;
-
-    // FIXME: disable bodge mode entirely. it's not really working.
-    // if (window.requestAnimationFrame) {
-    //   // wait a sec for it to settle down
-    //   setTimeout(() => {
-    //     this.calibrating = true;
-    //   }, this.calibrationDelay);
-    // } else {
-    //   console.log("requestAnimationFrame is not supported");
-    // }
+    this.onAnimationFrame = this.onAnimationFrame.bind(this);
+    this.running = true;
+    this.interval = 1e3 / FPS;
+    this.lastFrameTime = false;
   }
 
   start() {
     this.running = true;
     this.requestAnimationFrame();
-    if (this.bodgeMode) this.startBodgeMode();
   }
 
   stop() {
     this.running = false;
     if (this._requestID) window.cancelAnimationFrame(this._requestID);
-    if (this.bodgeInterval) clearInterval(this.bodgeInterval);
+    this.lastFrameTime = false;
   }
 
   requestAnimationFrame() {
     this._requestID = window.requestAnimationFrame(this.onAnimationFrame);
   }
 
-  onAnimationFrame = () => {
-    if (this.calibrating) {
-      if (this.calibrationStartTime === null) {
-        this.calibrationStartTime = new Date().getTime();
-        this.calibrationCurrentFrames = 0;
-      } else {
-        this.calibrationCurrentFrames += 1;
-      }
+  generateFrame() {
+    this.onGenerateFrame();
+    this.lastFrameTime += this.interval;
+  }
 
-      // Calibration complete!
-      if (this.calibrationCurrentFrames === this.calibrationFrames) {
-        this.calibrating = false;
-
-        var now = new Date().getTime();
-        var delta = now - this.calibrationStartTime;
-        var fps = 1000 / (delta / this.calibrationFrames);
-
-        if (
-          fps <= this.desiredFPS - this.calibrationTolerance ||
-          fps >= this.desiredFPS + this.calibrationTolerance
-        ) {
-          console.log(
-            `Enabling bodge mode. (Desired FPS is ${
-              this.desiredFPS
-            }, actual FPS is ${fps})`
-          );
-          this.startBodgeMode();
-        }
-      }
-    }
-
+  onAnimationFrame = time => {
     this.requestAnimationFrame();
+    // how many ms after 60fps frame time
+    let excess = time % this.interval;
 
-    if (this.running) {
-      if (!this.bodgeMode) {
-        this.onGenerateFrame();
-      }
-      this.onWriteFrame();
+    // newFrameTime is the current time aligned to 60fps intervals.
+    // i.e. 16.6, 33.3, etc ...
+    let newFrameTime = time - excess;
+
+    // first frame, do nothing
+    if (!this.lastFrameTime) {
+      this.lastFrameTime = newFrameTime;
+      return;
     }
-  };
 
-  startBodgeMode = () => {
-    this.bodgeMode = true;
-    this.bodgeInterval = setInterval(this.onBodge, 1000 / this.desiredFPS);
-  };
+    let numFrames = Math.round(
+      (newFrameTime - this.lastFrameTime) / this.interval
+    );
 
-  onBodge = () => {
-    if (this.running) {
-      this.onGenerateFrame();
+    // This can happen a lot on a 144Hz display
+    if (numFrames === 0) {
+      //console.log("WOAH, no frames");
+      return;
     }
+
+    // update display on first frame only
+    this.generateFrame();
+    this.onWriteFrame();
+
+    // we generate additional frames evenly before the next
+    // onAnimationFrame call.
+    // additional frames are generated but not displayed
+    // until next frame draw
+    let timeToNextFrame = this.interval - excess;
+    for (let i = 1; i < numFrames; i++) {
+      setTimeout(() => {
+        this.generateFrame();
+      }, (i * timeToNextFrame) / numFrames);
+    }
+    if (numFrames > 1) console.log("SKIP", numFrames - 1, this.lastFrameTime);
   };
 }

--- a/src/Speakers.js
+++ b/src/Speakers.js
@@ -34,6 +34,7 @@ export default class Speakers {
   writeSample = (left, right) => {
     if (this.buffer.size() / 2 >= this.bufferSize) {
       console.log(`Buffer overrun`);
+      this.buffer.deqN(this.bufferSize / 2);
     }
     this.buffer.enq(left);
     this.buffer.enq(right);


### PR DESCRIPTION
The timing module is rewritten to run at NTSC 60.098fps.

When requestAnimationFrame is triggered, the given time is rounded
down to the time of the latest frame that needs to be rendered. This
time is then used to determine how many frames the emulator is behind.

When the frame timer falls behind, frames are interlaced between the current
time and the time of the next frame render. For example, if there
is 6ms until the next frame render, and two extra frames are required,
they are generated at +2ms and +4ms.

The benefit of this approach is that it accommodates ANY framerate
given by requestAnimationFrame

See #15