### PR TITLE
Resolve warnings

### DIFF
--- a/src/ListPage.js
+++ b/src/ListPage.js
@@ -1,6 +1,6 @@
 import React, { Component } from "react";
 import "./ListPage.css";
-import { ListGroup, Button } from "reactstrap";
+import { ListGroup } from "reactstrap";
 import { Link } from "react-router-dom";
 import config from "./config";
 
@@ -64,7 +64,7 @@ class ListPage extends Component {
                         className="list-group-item"
                       >
                         {rom.name}
-                        <a
+                        <span
                           onClick={e => {
                             e.preventDefault();
                             this.deleteRom(rom.hash);
@@ -73,7 +73,7 @@ class ListPage extends Component {
                           title="Delete"
                         >
                           &times;
-                        </a>
+                        </span>
                         <span className="float-right">&rsaquo;</span>
                       </Link>
                     ))}

--- a/src/config.js
+++ b/src/config.js
@@ -9,11 +9,16 @@ const config = {
           <a
             href="http://www.gradualgames.com/p/the-legends-of-owlia_1.html"
             target="_blank"
+            rel="noopener noreferrer"
           >
             Owlia by Gradual Games
           </a>{" "}
           /{" "}
-          <a href="http://www.infiniteneslives.com/owlia.php" target="_blank">
+          <a
+            href="http://www.infiniteneslives.com/owlia.php"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
             Buy the cartridge
           </a>
         </span>
@@ -27,11 +32,16 @@ const config = {
           <a
             href="http://www.gradualgames.com/p/nomolos-storming-catsle.html"
             target="_blank"
+            rel="noopener noreferrer"
           >
             Monolos by Gradual Games
           </a>{" "}
           /{" "}
-          <a href="http://www.infiniteneslives.com/nomolos.php" target="_blank">
+          <a
+            href="http://www.infiniteneslives.com/nomolos.php"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
             Buy the cartridge
           </a>
         </span>
@@ -42,7 +52,11 @@ const config = {
       name: "Concentration Room",
       description: (
         <span>
-          <a href="http://www.pineight.com/croom/README" target="_blank">
+          <a
+            href="http://www.pineight.com/croom/README"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
             Concentration Room
           </a>{" "}
           by Damian Yerrick
@@ -55,7 +69,11 @@ const config = {
       name: "LJ65",
       description: (
         <span>
-          <a href="http://harddrop.com/wiki/LJ65" target="_blank">
+          <a
+            href="http://harddrop.com/wiki/LJ65"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
             Concentration Room
           </a>{" "}
           by Damian Yerrick


### PR DESCRIPTION
Cleans up a bunch of warnings. Namely these ones:

<img width="702" alt="Screen Shot 2019-10-17 at 9 43 10 PM" src="https://user-images.githubusercontent.com/10043207/67059484-4b3fc600-f127-11e9-8471-0804d8d3742b.png">

As well as this one:

<img width="535" alt="image" src="https://user-images.githubusercontent.com/10043207/67059634-dcaf3800-f127-11e9-8278-d7dd96e7942d.png">

Note: there's still a `react-ga` warning that I left unresolved in this, but all linter warnings are taken care of.

Also, checks will fail for this PR until https://github.com/bfirsh/jsnes-web/pull/244 is merged, as the app in its current form cannot be built.