### PR TITLE
Make the drop zone span the whole screen

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,3 +1,7 @@
+.App {
+  height: 100%;
+}
+
 .App,
 .modal-dialog {
   font-family: Menlo, monospace;

--- a/src/ListPage.css
+++ b/src/ListPage.css
@@ -10,3 +10,7 @@
 .ListPage .list-group-item .delete:hover {
   color: darkred;
 }
+
+.drop-zone {
+  height: 100%;
+}

--- a/src/ListPage.js
+++ b/src/ListPage.js
@@ -16,70 +16,74 @@ class ListPage extends Component {
   render() {
     return (
       <div
-        className="container ListPage my-4"
+        className="drop-zone"
         onDragOver={this.handleDragOver}
         onDrop={this.handleDrop}
       >
-        <div className="row justify-content-center">
-          <div className="col-md-8">
-            <header className="mb-4">
-              <h1 className="mb-3">JSNES</h1>
+        <div className="container ListPage py-4">
+          <div className="row justify-content-center">
+            <div className="col-md-8">
+              <header className="mb-4">
+                <h1 className="mb-3">JSNES</h1>
+                <p>
+                  A JavaScript NES emulator.{" "}
+                  <a href="https://github.com/bfirsh/jsnes">
+                    Source on GitHub.
+                  </a>
+                </p>
+              </header>
+
+              <ListGroup className="mb-4">
+                {Object.keys(config.ROMS)
+                  .sort()
+                  .map(key => (
+                    <Link
+                      key={key}
+                      to={"/run/" + encodeURIComponent(key)}
+                      className="list-group-item"
+                    >
+                      {config.ROMS[key]["name"]}
+                      <span className="float-right">&rsaquo;</span>
+                    </Link>
+                  ))}
+              </ListGroup>
+
               <p>
-                A JavaScript NES emulator.{" "}
-                <a href="https://github.com/bfirsh/jsnes">Source on GitHub.</a>
+                Or, drag and drop a ROM file onto the page to play it. (Google
+                may help you find them.)
               </p>
-            </header>
 
-            <ListGroup className="mb-4">
-              {Object.keys(config.ROMS)
-                .sort()
-                .map(key => (
-                  <Link
-                    key={key}
-                    to={"/run/" + encodeURIComponent(key)}
-                    className="list-group-item"
-                  >
-                    {config.ROMS[key]["name"]}
-                    <span className="float-right">&rsaquo;</span>
-                  </Link>
-                ))}
-            </ListGroup>
+              {this.state.romLibrary.length > 0 ? (
+                <div>
+                  <p>Previously played:</p>
 
-            <p>
-              Or, drag and drop a ROM file onto the page to play it. (Google may
-              help you find them.)
-            </p>
-
-            {this.state.romLibrary.length > 0 ? (
-              <div>
-                <p>Previously played:</p>
-
-                <ListGroup className="mb-4">
-                  {this.state.romLibrary
-                    .sort((a, b) => new Date(b.added) - new Date(a.added))
-                    .map(rom => (
-                      <Link
-                        key={rom.hash}
-                        to={"run/local-" + rom.hash}
-                        className="list-group-item"
-                      >
-                        {rom.name}
-                        <span
-                          onClick={e => {
-                            e.preventDefault();
-                            this.deleteRom(rom.hash);
-                          }}
-                          className="delete"
-                          title="Delete"
+                  <ListGroup className="mb-4">
+                    {this.state.romLibrary
+                      .sort((a, b) => new Date(b.added) - new Date(a.added))
+                      .map(rom => (
+                        <Link
+                          key={rom.hash}
+                          to={"run/local-" + rom.hash}
+                          className="list-group-item"
                         >
-                          &times;
-                        </span>
-                        <span className="float-right">&rsaquo;</span>
-                      </Link>
-                    ))}
-                </ListGroup>
-              </div>
-            ) : null}
+                          {rom.name}
+                          <span
+                            onClick={e => {
+                              e.preventDefault();
+                              this.deleteRom(rom.hash);
+                            }}
+                            className="delete"
+                            title="Delete"
+                          >
+                            &times;
+                          </span>
+                          <span className="float-right">&rsaquo;</span>
+                        </Link>
+                      ))}
+                  </ListGroup>
+                </div>
+              ) : null}
+            </div>
           </div>
         </div>
       </div>

--- a/src/index.scss
+++ b/src/index.scss
@@ -39,6 +39,10 @@ $close-text-shadow: none;
   }
 }
 
+html, body, #root {
+  height: 100%;
+}
+
 .nav-link {
   text-decoration: none;
 }


### PR DESCRIPTION
Fixes #221.

Some style changes as well as bootstrap class usage changes were necessary in order to allow the drop zone to fill the height of the screen. Pointer events should also properly function with elements within the drop zone.

Note: checks will fail for this PR until https://github.com/bfirsh/jsnes-web/pull/244 is merged, as the app in its current form cannot be built.