### PR TITLE
Add Publication to Github Pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "dependencies": {
     "bootstrap": "4.2.1",
-    "jsnes": "git://github.com/bfirsh/jsnes.git",
+    "jsnes": "git+ssh://github.com/bfirsh/jsnes.git",
     "node-sass": "^4.13.1",
     "prop-types": "^15.7.2",
     "raven-js": "^3.27.2",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "homepage": ".",
   "dependencies": {
     "bootstrap": "4.2.1",
-    "jsnes": "git+ssh://github.com/bfirsh/jsnes.git",
+    "jsnes": "git+ssh://git@github.com/bfirsh/jsnes.git",
     "node-sass": "^4.13.1",
     "prop-types": "^15.7.2",
     "raven-js": "^3.27.2",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "homepage": ".",
   "dependencies": {
     "bootstrap": "4.2.1",
+    "gh-pages": "^4.0.0",
     "jsnes": "git+ssh://git@github.com/bfirsh/jsnes.git",
     "node-sass": "^4.13.1",
     "prop-types": "^15.7.2",
@@ -28,7 +29,9 @@
     "build": "react-scripts build",
     "test": "prettier-check src/**/*.js && react-scripts test",
     "eject": "react-scripts eject",
-    "format": "prettier --write src/**/*.js"
+    "format": "prettier --write src/**/*.js",
+    "publish": "gh-pages --dist build"
+
   },
   "browserslist": [
     ">0.2%",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "license": "Apache-2.0",
   "private": true,
+  "homepage": ".",
   "dependencies": {
     "bootstrap": "4.2.1",
     "jsnes": "git+ssh://github.com/bfirsh/jsnes.git",

--- a/src/App.js
+++ b/src/App.js
@@ -29,7 +29,7 @@ class App extends Component {
       );
     }
     return (
-      <BrowserRouter basename={config.BASENAME}>
+      <BrowserRouter basename={config.BASENAME()}>
         <div className="App">
           <Route exact path="/" component={ListPage} />
           <Route exact path="/run" component={RunPage} />

--- a/src/App.js
+++ b/src/App.js
@@ -29,7 +29,7 @@ class App extends Component {
       );
     }
     return (
-      <BrowserRouter>
+      <BrowserRouter basename={config.BASENAME}>
         <div className="App">
           <Route exact path="/" component={ListPage} />
           <Route exact path="/run" component={RunPage} />

--- a/src/ListPage.js
+++ b/src/ListPage.js
@@ -6,8 +6,8 @@ import config from "./config";
 
 import RomLibrary from "./RomLibrary";
 
-const rootRunPath = `${config.BASENAME}/run`;
-const rootRunPathLocal = `${config.BASENAME}/local-`;
+const rootRunPath = "/run";
+const rootRunPathLocal = "/local-";
 
 class ListPage extends Component {
   constructor(props) {

--- a/src/ListPage.js
+++ b/src/ListPage.js
@@ -6,6 +6,9 @@ import config from "./config";
 
 import RomLibrary from "./RomLibrary";
 
+const rootRunPath = `${config.BASENAME}/run`;
+const rootRunPathLocal = `${config.BASENAME}/local-`;
+
 class ListPage extends Component {
   constructor(props) {
     super(props);
@@ -39,7 +42,7 @@ class ListPage extends Component {
                   .map(key => (
                     <Link
                       key={key}
-                      to={"/run/" + encodeURIComponent(key)}
+                      to={rootRunPath + "/" +  encodeURIComponent(key)}
                       className="list-group-item"
                     >
                       {config.ROMS[key]["name"]}
@@ -63,7 +66,7 @@ class ListPage extends Component {
                       .map(rom => (
                         <Link
                           key={rom.hash}
-                          to={"run/local-" + rom.hash}
+                          to={rootRunPathLocal + rom.hash}
                           className="list-group-item"
                         >
                           {rom.name}
@@ -113,7 +116,7 @@ class ListPage extends Component {
 
     RomLibrary.save(file).then(rom => {
       this.updateLibrary();
-      this.props.history.push({ pathname: "run/local-" + rom.hash });
+      this.props.history.push({ pathname:  + rom.hash });
     });
   };
 }

--- a/src/ListPage.js
+++ b/src/ListPage.js
@@ -42,7 +42,7 @@ class ListPage extends Component {
                   .map(key => (
                     <Link
                       key={key}
-                      to={rootRunPath + "/" +  encodeURIComponent(key)}
+                      to={rootRunPath + "/" + encodeURIComponent(key)}
                       className="list-group-item"
                     >
                       {config.ROMS[key]["name"]}
@@ -116,7 +116,7 @@ class ListPage extends Component {
 
     RomLibrary.save(file).then(rom => {
       this.updateLibrary();
-      this.props.history.push({ pathname:  + rom.hash });
+      this.props.history.push({ pathname: +rom.hash });
     });
   };
 }

--- a/src/config.js
+++ b/src/config.js
@@ -83,7 +83,8 @@ const config = {
     }
   },
   GOOGLE_ANALYTICS_CODE: process.env.REACT_APP_GOOGLE_ANALYTICS_CODE,
-  SENTRY_URI: process.env.REACT_APP_SENTRY_URI
+  SENTRY_URI: process.env.REACT_APP_SENTRY_URI,
+  BASENAME: ""
 };
 
 export default config;

--- a/src/config.js
+++ b/src/config.js
@@ -95,7 +95,7 @@ const config = {
 
     // default case, we don't have a base path
     // good for localhost
-    return ""
+    return "";
   }
 };
 

--- a/src/config.js
+++ b/src/config.js
@@ -84,7 +84,19 @@ const config = {
   },
   GOOGLE_ANALYTICS_CODE: process.env.REACT_APP_GOOGLE_ANALYTICS_CODE,
   SENTRY_URI: process.env.REACT_APP_SENTRY_URI,
-  BASENAME: ""
+  BASENAME: () => {
+    const url = window.location.href;
+    // we're on github pages, which means we have a subpath
+    if (url.includes("github.io")) {
+      const parts = url.split("/");
+      // ["https:/","/","...github.io/",$money]
+      return `/${parts[3]}`;
+    }
+
+    // default case, we don't have a base path
+    // good for localhost
+    return ""
+  }
 };
 
 export default config;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2134,6 +2134,13 @@ async-limiter@~1.0.0:
   resolved "https://registry.yarnpkg.com/async-limiter/-/async-limiter-1.0.0.tgz#78faed8c3d074ab81f22b4e985d79e8738f720f8"
   integrity sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==
 
+async@^2.6.1:
+  version "2.6.4"
+  resolved "https://registry.yarnpkg.com/async/-/async-2.6.4.tgz#706b7ff6084664cd7eae713f6f965433b5504221"
+  integrity sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==
+  dependencies:
+    lodash "^4.17.14"
+
 async@^2.6.2:
   version "2.6.3"
   resolved "https://registry.yarnpkg.com/async/-/async-2.6.3.tgz#d72625e2344a3656e3a3ad4fa749fa83299d82ff"
@@ -3087,7 +3094,7 @@ commander@^2.11.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.19.0.tgz#f6198aa84e5b83c46054b94ddedbfed5ee9ff12a"
   integrity sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==
 
-commander@^2.20.0:
+commander@^2.18.0, commander@^2.20.0:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
@@ -4070,6 +4077,11 @@ elliptic@^6.0.0:
     minimalistic-assert "^1.0.1"
     minimalistic-crypto-utils "^1.0.1"
 
+email-addresses@^3.0.1:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/email-addresses/-/email-addresses-3.1.0.tgz#cabf7e085cbdb63008a70319a74e6136188812fb"
+  integrity sha512-k0/r7GrWVL32kZlGwfPNgB2Y/mMXVTq/decgLczm/j34whdaspNrZO8CnXPf1laaHxI6ptUlsnAxN+UAPw+fzg==
+
 emoji-regex@^7.0.1, emoji-regex@^7.0.2:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-7.0.3.tgz#933a04052860c85e83c122479c4748a8e4c72156"
@@ -4749,6 +4761,20 @@ file-uri-to-path@1.0.0:
   resolved "https://registry.yarnpkg.com/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz#553a7b8446ff6f684359c445f1e37a05dacc33dd"
   integrity sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==
 
+filename-reserved-regex@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/filename-reserved-regex/-/filename-reserved-regex-2.0.0.tgz#abf73dfab735d045440abfea2d91f389ebbfa229"
+  integrity sha512-lc1bnsSr4L4Bdif8Xb/qrtokGbq5zlsms/CYH8PP+WtCkGNF65DPiQY8vG3SakEdRn8Dlnm+gW/qWKKjS5sZzQ==
+
+filenamify@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/filenamify/-/filenamify-4.3.0.tgz#62391cb58f02b09971c9d4f9d63b3cf9aba03106"
+  integrity sha512-hcFKyUG57yWGAzu1CMt/dPzYZuv+jAJUT85bL8mrXvNe6hWj6yEHEc4EdcgiA6Z3oi1/9wXJdZPXF2dZNgwgOg==
+  dependencies:
+    filename-reserved-regex "^2.0.0"
+    strip-outer "^1.0.1"
+    trim-repeated "^1.0.0"
+
 filesize@6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/filesize/-/filesize-6.0.1.tgz#f850b509909c7c86f7e450ea19006c31c2ed3d2f"
@@ -4806,6 +4832,15 @@ find-cache-dir@^3.2.0:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/find-cache-dir/-/find-cache-dir-3.3.1.tgz#89b33fad4a4670daa94f855f7fbe31d6d84fe880"
   integrity sha512-t2GDMt3oGC/v+BMwzmllWDuJF/xcDtE5j/fCGbqDD7OLuJkj0cfh1YSA5VKPvwMeLFLNDBkwOKZ2X85jGLVftQ==
+  dependencies:
+    commondir "^1.0.1"
+    make-dir "^3.0.2"
+    pkg-dir "^4.1.0"
+
+find-cache-dir@^3.3.1:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/find-cache-dir/-/find-cache-dir-3.3.2.tgz#b30c5b6eff0730731aea9bbd9dbecbd80256d64b"
+  integrity sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==
   dependencies:
     commondir "^1.0.1"
     make-dir "^3.0.2"
@@ -5011,7 +5046,6 @@ fsevents@^1.2.7:
   dependencies:
     bindings "^1.5.0"
     nan "^2.12.1"
-    node-pre-gyp "*"
 
 fstream@^1.0.0, fstream@^1.0.12:
   version "1.0.12"
@@ -5102,6 +5136,19 @@ getpass@^0.1.1:
   integrity sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=
   dependencies:
     assert-plus "^1.0.0"
+
+gh-pages@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/gh-pages/-/gh-pages-4.0.0.tgz#bd7447bab7eef008f677ac8cc4f6049ab978f4a6"
+  integrity sha512-p8S0T3aGJc68MtwOcZusul5qPSNZCalap3NWbhRUZYu1YOdp+EjZ+4kPmRM8h3NNRdqw00yuevRjlkuSzCn7iQ==
+  dependencies:
+    async "^2.6.1"
+    commander "^2.18.0"
+    email-addresses "^3.0.1"
+    filenamify "^4.3.0"
+    find-cache-dir "^3.3.1"
+    fs-extra "^8.1.0"
+    globby "^6.1.0"
 
 glob-parent@^3.1.0:
   version "3.1.0"
@@ -6698,10 +6745,9 @@ jsesc@~0.5.0:
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-0.5.0.tgz#e7dee66e35d6fc16f710fe91d5cf69f70f08911d"
   integrity sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=
 
-"jsnes@git://github.com/bfirsh/jsnes.git":
+"jsnes@git+ssh://git@github.com/bfirsh/jsnes.git":
   version "1.2.1"
-  uid "9c40bd9bc1525682fc473e10665487e8cc56b5b1"
-  resolved "git://github.com/bfirsh/jsnes.git#9c40bd9bc1525682fc473e10665487e8cc56b5b1"
+  resolved "git+ssh://git@github.com/bfirsh/jsnes.git#d8021d0336cb5c1cf924cd660ecf816bec15c11a"
 
 json-parse-better-errors@^1.0.1, json-parse-better-errors@^1.0.2:
   version "1.0.2"
@@ -7391,14 +7437,6 @@ minipass@^2.2.1, minipass@^2.3.4:
     safe-buffer "^5.1.2"
     yallist "^3.0.0"
 
-minipass@^2.8.6, minipass@^2.9.0:
-  version "2.9.0"
-  resolved "https://registry.yarnpkg.com/minipass/-/minipass-2.9.0.tgz#e713762e7d3e32fed803115cf93e04bca9fcc9a6"
-  integrity sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==
-  dependencies:
-    safe-buffer "^5.1.2"
-    yallist "^3.0.0"
-
 minipass@^3.0.0, minipass@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/minipass/-/minipass-3.1.1.tgz#7607ce778472a185ad6d89082aa2070f79cedcd5"
@@ -7412,13 +7450,6 @@ minizlib@^1.1.1:
   integrity sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==
   dependencies:
     minipass "^2.2.1"
-
-minizlib@^1.2.1:
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-1.3.3.tgz#2290de96818a34c29551c8a8d301216bd65a861d"
-  integrity sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==
-  dependencies:
-    minipass "^2.9.0"
 
 mississippi@^3.0.0:
   version "3.0.0"
@@ -7652,22 +7683,6 @@ node-notifier@^5.4.2:
     semver "^5.5.0"
     shellwords "^0.1.1"
     which "^1.3.0"
-
-node-pre-gyp@*:
-  version "0.14.0"
-  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.14.0.tgz#9a0596533b877289bcad4e143982ca3d904ddc83"
-  integrity sha512-+CvDC7ZttU/sSt9rFjix/P05iS43qHCOOGzcr3Ry99bXG7VX953+vFyEuph/tfqoYu8dttBkE86JSKBO2OzcxA==
-  dependencies:
-    detect-libc "^1.0.2"
-    mkdirp "^0.5.1"
-    needle "^2.2.1"
-    nopt "^4.0.1"
-    npm-packlist "^1.1.6"
-    npmlog "^4.0.2"
-    rc "^1.2.7"
-    rimraf "^2.6.1"
-    semver "^5.3.0"
-    tar "^4.4.2"
 
 node-pre-gyp@^0.11.0:
   version "0.11.0"
@@ -10972,6 +10987,13 @@ strip-json-comments@~2.0.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
   integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
 
+strip-outer@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/strip-outer/-/strip-outer-1.0.1.tgz#b2fd2abf6604b9d1e6013057195df836b8a9d631"
+  integrity sha512-k55yxKHwaXnpYGsOzg4Vl8+tDrWylxDEpknGjhTiZB8dFRU5rTo9CAzeycivxV3s+zlTKwrs6WxMxR95n26kwg==
+  dependencies:
+    escape-string-regexp "^1.0.2"
+
 style-loader@0.23.1:
   version "0.23.1"
   resolved "https://registry.yarnpkg.com/style-loader/-/style-loader-0.23.1.tgz#cb9154606f3e771ab6c4ab637026a1049174d925"
@@ -11105,19 +11127,6 @@ tar@^4:
     mkdirp "^0.5.0"
     safe-buffer "^5.1.2"
     yallist "^3.0.2"
-
-tar@^4.4.2:
-  version "4.4.13"
-  resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.13.tgz#43b364bc52888d555298637b10d60790254ab525"
-  integrity sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==
-  dependencies:
-    chownr "^1.1.1"
-    fs-minipass "^1.2.5"
-    minipass "^2.8.6"
-    minizlib "^1.2.1"
-    mkdirp "^0.5.0"
-    safe-buffer "^5.1.2"
-    yallist "^3.0.3"
 
 terser-webpack-plugin@2.3.5:
   version "2.3.5"
@@ -11309,6 +11318,13 @@ trim-newlines@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-1.0.0.tgz#5887966bb582a4503a41eb524f7d35011815a613"
   integrity sha1-WIeWa7WCpFA6QetST301ARgVphM=
+
+trim-repeated@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/trim-repeated/-/trim-repeated-1.0.0.tgz#e3646a2ea4e891312bf7eace6cfb05380bc01c21"
+  integrity sha512-pkonvlKk8/ZuR0D5tLW8ljt5I8kmxp2XKymhepUeOdCEfKpZaktSArkLHZt76OB1ZvO9bssUsDty4SWhLvZpLg==
+  dependencies:
+    escape-string-regexp "^1.0.2"
 
 trim-right@^1.0.1:
   version "1.0.1"
@@ -12105,11 +12121,6 @@ yallist@^3.0.0, yallist@^3.0.2:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.0.3.tgz#b4b049e314be545e3ce802236d6cd22cd91c3de9"
   integrity sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==
-
-yallist@^3.0.3:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
-  integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==
 
 yallist@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
Updates the project to easily run on GitHub Pages.  This is particularly useful for forks which might make changes (adding their own roms) and wish to present that to the world. 

Adds a single command `yarn run publish` to push to gh-pages.  I'm open to a different command as `yarn publish` is very different thing.

Major motivation was the ability to fork the project, change the config to show my rom, and then push it to the world for use.

FIXES: #371 

(NOTE: Resubmission of #373)